### PR TITLE
More detailed UnknownScopeException method

### DIFF
--- a/src/Ninject.Extensions.NamedScope/ExceptionFormatter.cs
+++ b/src/Ninject.Extensions.NamedScope/ExceptionFormatter.cs
@@ -1,0 +1,38 @@
+﻿using System.IO;
+using Ninject.Activation;
+using Ninject.Infrastructure.Introspection;
+
+namespace Ninject.Extensions.NamedScope
+{
+    /// <summary>
+    /// Provides meaningful exception messages.
+    /// </summary>
+    public static class ExceptionFormatter
+    {
+        /// <summary>
+        /// Generates a message saying that the binding could not be resolved due to unknown scope
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="scopeName">Scope name</param>
+        /// <returns>The exception message.</returns>
+        public static string CouldNotFindScope(IRequest request, string scopeName)
+        {
+            using (var sw = new StringWriter())
+            {
+                sw.WriteLine("Error activating {0}", request.Service.Format());
+                sw.WriteLine("The scope {0} is not known in the current context.", scopeName);
+                sw.WriteLine("No matching scopes are available, and the type is declared InNamedScope({0}).", scopeName);
+
+                sw.WriteLine("Activation path:");
+                sw.WriteLine(request.FormatActivationPath());
+
+                sw.WriteLine("Suggestions:");
+                sw.WriteLine("  1) Ensure that you have defined the scope {0}.", scopeName);//request.Service.Format());
+                sw.WriteLine("  2) Ensure you have a parent resolution that defines the scope.");
+                sw.WriteLine("  3) If you are using factory methods or late resolution, check that the correct IResolutionRoot is being used.");
+
+                return sw.ToString();
+            }
+        }
+    }
+}

--- a/src/Ninject.Extensions.NamedScope/NamedScopeExtensionMethods.cs
+++ b/src/Ninject.Extensions.NamedScope/NamedScopeExtensionMethods.cs
@@ -17,6 +17,8 @@
 // </copyright>
 //-------------------------------------------------------------------------------
 
+using Ninject.Infrastructure.Introspection;
+
 namespace Ninject.Extensions.NamedScope
 {
     using System.Linq;
@@ -123,7 +125,7 @@ namespace Ninject.Extensions.NamedScope
                 return GetScope(context.Request.ParentContext, scopeParameterName);
             }
 
-            throw new UnknownScopeException(scopeParameterName);
+            throw new UnknownScopeException(ExceptionFormatter.CouldNotFindScope(context.Request, scopeParameterName));
         }
 
         /// <summary>

--- a/src/Ninject.Extensions.NamedScope/Ninject.Extensions.NamedScope.csproj
+++ b/src/Ninject.Extensions.NamedScope/Ninject.Extensions.NamedScope.csproj
@@ -71,6 +71,7 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="DisposeNotifyingObject.cs" />
+    <Compile Include="ExceptionFormatter.cs" />
     <Compile Include="NamedScope.cs" />
     <Compile Include="NamedScopeActivationStrategy.cs" />
     <Compile Include="NamedScopeExtensionMethods.cs" />

--- a/src/Ninject.Extensions.NamedScope/UnknownScopeException.cs
+++ b/src/Ninject.Extensions.NamedScope/UnknownScopeException.cs
@@ -20,7 +20,6 @@
 namespace Ninject.Extensions.NamedScope
 {
     using System;
-    using System.Globalization;
 
     /// <summary>
     /// This exception is thrown when a binding requests a scope that is not defined in the current scope.
@@ -30,9 +29,9 @@ namespace Ninject.Extensions.NamedScope
         /// <summary>
         /// Initializes a new instance of the <see cref="UnknownScopeException"/> class.
         /// </summary>
-        /// <param name="scopeName">Name of the scope.</param>
-        public UnknownScopeException(string scopeName)
-            : base(string.Format(CultureInfo.InvariantCulture, "The scope {0} is not known in the current context.", scopeName))
+        /// <param name="message">Error message - detailed</param>
+        public UnknownScopeException(string message)
+            : base(message)
         {
         }
     }


### PR DESCRIPTION
Added a more detailed exception when an UnknownScopeException is thrown.

It is very hard to find out what injection request is failing due to an UnknownScopeException.

These changes use the ExceptionFormatter pattern (from Ninject) to do the same within NamedScope extension.

I've just noticed the line endings are wrong (way too many changes) but am unsure exactly how to resolve this at the moment.
