### PR TITLE
InCallScope fix for multiple factories and property injection

### DIFF
--- a/src/Ninject.Extensions.NamedScope.Test/NamedScopeContextPreservationIntegrationTest.cs
+++ b/src/Ninject.Extensions.NamedScope.Test/NamedScopeContextPreservationIntegrationTest.cs
@@ -155,6 +155,29 @@ namespace Ninject.Extensions.NamedScope
         }
 
         /// <summary>
+        /// The call scope takes the object resolved by the last Get as scope. But ToMethod(ctx => ctx.ContextPreservingGet) 
+        /// is excluded. 
+        /// </summary>
+        [Fact]
+        public void CallScopeWorksOverFactories()
+        {
+            this.kernel.Bind<ParentWithFactoryFactory>().ToSelf();
+            this.kernel.Bind<FactoryFactory>().ToSelf().InTransientScope();
+            this.kernel.Bind<Factory>().ToSelf().InTransientScope();
+            this.kernel.Bind<Child>().ToSelf().InTransientScope();
+            this.kernel.Bind<IGrandChild, GrandChild>().To<GrandChild>().InCallScope();
+
+            var parent = this.kernel.Get<ParentWithFactoryFactory>();
+            var child1 = parent.CreateChild();
+            var child2 = parent.CreateChild();
+            parent.Dispose();
+
+            child1.GrandChild.Should().BeSameAs(child1.GrandChild2);
+            child1.GrandChild.Should().NotBeSameAs(child2.GrandChild);
+            child1.GrandChild.IsDisposed.Should().BeFalse();
+        }
+
+        /// <summary>
         /// CreateNamedScope can be used to create a named scope for objects requested by this
         /// resolution root.
         /// </summary>

--- a/src/Ninject.Extensions.NamedScope.Test/NamedScopeIntegrationTest.cs
+++ b/src/Ninject.Extensions.NamedScope.Test/NamedScopeIntegrationTest.cs
@@ -147,6 +147,35 @@ namespace Ninject.Extensions.NamedScope
         }
 
         /// <summary>
+        /// Bindings with parent scope are disposed with their parents.
+        /// </summary>
+        [Fact]
+        public void CallScopeWithPropertyInjection()
+        {
+            this.kernel.Bind<ParentWithPropertyInjection>().ToSelf();
+            this.kernel.Bind<Child>().ToSelf().InCallScope();
+            this.kernel.Bind<IGrandChild>().To<GrandChild>().InCallScope();
+
+            var parent1 = this.kernel.Get<ParentWithPropertyInjection>();
+            var parent2 = this.kernel.Get<ParentWithPropertyInjection>();
+            parent1.Dispose();
+
+            parent1.FirstChild.Should().BeSameAs(parent1.SecondChild);
+            parent1.GrandChild.Should().BeSameAs(parent1.FirstChild.GrandChild);
+            parent1.FirstChild.Should().NotBeSameAs(parent2.FirstChild);
+            parent1.GrandChild.Should().NotBeSameAs(parent2.GrandChild);
+
+            parent1.FirstChild.IsDisposed.Should().BeTrue();
+            parent1.FirstChild.GrandChild.IsDisposed.Should().BeTrue();
+            parent2.FirstChild.IsDisposed.Should().BeFalse();
+            parent2.FirstChild.GrandChild.IsDisposed.Should().BeFalse();
+
+            parent2.Dispose();
+            parent2.FirstChild.IsDisposed.Should().BeTrue();
+            parent2.FirstChild.GrandChild.IsDisposed.Should().BeTrue();
+        }
+
+        /// <summary>
         /// If the scope of a binding is not found an <see cref="UnknownScopeException"/>
         /// is thrown.
         /// </summary>

--- a/src/Ninject.Extensions.NamedScope.Test/Ninject.Extensions.NamedScope.Test.csproj
+++ b/src/Ninject.Extensions.NamedScope.Test/Ninject.Extensions.NamedScope.Test.csproj
@@ -81,6 +81,7 @@
   <ItemGroup>
     <Compile Include="TestTypes\Child.cs" />
     <Compile Include="TestTypes\Factory.cs" />
+    <Compile Include="TestTypes\FactoryFactory.cs" />
     <Compile Include="TestTypes\IFirstInterface.cs" />
     <Compile Include="DisposeNotifyingObjectTest.cs" />
     <Compile Include="TestTypes\GrandChild.cs" />
@@ -95,6 +96,8 @@
     <Compile Include="TestTypes\ParentWithFactory.cs" />
     <Compile Include="TestTypes\ParentWithMultiInterfaceClass.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestTypes\ParentWithFactoryFactory.cs" />
+    <Compile Include="TestTypes\ParentWithPropertyInjection.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ninject.Extensions.NamedScope\Ninject.Extensions.NamedScope.csproj">

--- a/src/Ninject.Extensions.NamedScope.Test/TestTypes/FactoryFactory.cs
+++ b/src/Ninject.Extensions.NamedScope.Test/TestTypes/FactoryFactory.cs
@@ -1,0 +1,52 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="Factory.cs" company="bbv Software Services AG">
+//   Copyright (c) 2010 bbv Software Services AG
+//   Author: Remo Gloor remo.gloor@bbv.ch
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+namespace Ninject.Extensions.NamedScope.TestTypes
+{
+    using Ninject.Syntax;
+
+    /// <summary>
+    /// A factory class.
+    /// </summary>
+    public class FactoryFactory : DisposeNotifyingObject
+    {
+        /// <summary>
+        /// The resolution root that is used to create new objects.
+        /// </summary>
+        private readonly IResolutionRoot resolutionRoot;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FactoryFactory"/> class.
+        /// </summary>
+        /// <param name="resolutionRoot">The resolution root.</param>
+        public FactoryFactory(IResolutionRoot resolutionRoot)
+        {
+            this.resolutionRoot = resolutionRoot;
+        }
+
+        /// <summary>
+        /// Creates the factory.
+        /// </summary>
+        /// <returns>The newly created factory.</returns>
+        public Factory CreateFactory()
+        {
+            return this.resolutionRoot.Get<Factory>();
+        }
+    }
+}

--- a/src/Ninject.Extensions.NamedScope.Test/TestTypes/ParentWithFactoryFactory.cs
+++ b/src/Ninject.Extensions.NamedScope.Test/TestTypes/ParentWithFactoryFactory.cs
@@ -1,0 +1,50 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="ParentWithFactory.cs" company="bbv Software Services AG">
+//   Copyright (c) 2010 bbv Software Services AG
+//   Author: Remo Gloor remo.gloor@bbv.ch
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+namespace Ninject.Extensions.NamedScope.TestTypes
+{
+    /// <summary>
+    /// A parent that has a factory for creation of other factories.
+    /// </summary>
+    public class ParentWithFactoryFactory : DisposeNotifyingObject
+    {
+        /// <summary>
+        /// The factory factory.
+        /// </summary>
+        private readonly FactoryFactory factoryFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParentWithFactoryFactory"/> class.
+        /// </summary>
+        /// <param name="factoryFactory">The factory factory.</param>
+        public ParentWithFactoryFactory(FactoryFactory factoryFactory)
+        {
+            this.factoryFactory = factoryFactory;
+        }
+
+        /// <summary>
+        /// Creates a new child using the factory factory.
+        /// </summary>
+        /// <returns>The created child.</returns>
+        public Child CreateChild()
+        {
+            return this.factoryFactory.CreateFactory().CreateChild();
+        }
+    }
+}

--- a/src/Ninject.Extensions.NamedScope.Test/TestTypes/ParentWithPropertyInjection.cs
+++ b/src/Ninject.Extensions.NamedScope.Test/TestTypes/ParentWithPropertyInjection.cs
@@ -1,0 +1,56 @@
+﻿//-------------------------------------------------------------------------------
+// <copyright file="Parent.cs" company="bbv Software Services AG">
+//   Copyright (c) 2010 bbv Software Services AG
+//   Author: Remo Gloor remo.gloor@bbv.ch
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+//-------------------------------------------------------------------------------
+
+namespace Ninject.Extensions.NamedScope.TestTypes
+{
+    /// <summary>
+    /// The parent used in the tests
+    /// </summary>
+    public class ParentWithPropertyInjection : DisposeNotifyingObject
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ParentWithPropertyInjection"/> class.
+        /// </summary>
+        /// <param name="grandChild">The grand child.</param>
+        public ParentWithPropertyInjection(IGrandChild grandChild)
+        {
+            this.GrandChild = grandChild;
+        }
+
+        /// <summary>
+        /// Gets the first child.
+        /// </summary>
+        /// <value>The first child.</value>
+        [Inject]
+        public Child FirstChild { get; set; }
+
+        /// <summary>
+        /// Gets the second child.
+        /// </summary>
+        /// <value>The second child.</value>
+        [Inject]
+        public Child SecondChild { get; set; }
+
+        /// <summary>
+        /// Gets the grand child.
+        /// </summary>
+        /// <value>The second child.</value>
+        public IGrandChild GrandChild { get; private set; }
+    }
+}

--- a/src/Ninject.Extensions.NamedScope/NamedScopeExtensionMethods.cs
+++ b/src/Ninject.Extensions.NamedScope/NamedScopeExtensionMethods.cs
@@ -69,9 +69,8 @@ namespace Ninject.Extensions.NamedScope
                 context =>
                 {
                     const string ScopeParameterName = "NamedScopeInCallScope";
-                    var rootContext = context.Request.ParentContext ?? context;
-                    while (rootContext.Request.ParentContext != null &&
-                           !IsBindingActivated(rootContext.Request.ParentContext))
+                    var rootContext = context;
+                    while (!IsCurrentResolveRoot(rootContext) && rootContext.Request.ParentContext != null)
                     {
                         rootContext = rootContext.Request.ParentContext;
                     }
@@ -136,17 +135,12 @@ namespace Ninject.Extensions.NamedScope
         {
             return resolutionRoot.Get<NamedScope>(new NamedScopeParameter(scopeName));
         }
-
-        /// <summary>
-        /// Determines whether the binding of the specified context is currently activated.
-        /// </summary>
-        /// <param name="context">The context.</param>
-        /// <returns><c>true</c> if the binding of the specified context is currently activated; otherwise, <c>false</c>.</returns>
-        private static bool IsBindingActivated(IContext context)
-        {
-            return context.Request.ActiveBindings.First() != context.Binding;
-        }
         
+        private static bool IsCurrentResolveRoot(IContext context)
+        {
+            return context.Request.GetType().FullName == "Ninject.Extensions.ContextPreservation.ContextPreservingResolutionRoot+ContextPreservingRequest";
+        }
+
         /// <summary>
         /// Gets a named scope parameter from a context.
         /// </summary>


### PR DESCRIPTION
Fixed InCallScope to
- support multiple factories over context preservation
- support property injection
