### PR TITLE
Fixed NamedScopeReference.Dispose(bool)

### DIFF
--- a/src/Ninject.Extensions.NamedScope.Test/NamedScopeReferenceTest.cs
+++ b/src/Ninject.Extensions.NamedScope.Test/NamedScopeReferenceTest.cs
@@ -42,6 +42,21 @@ namespace Ninject.Extensions.NamedScope
 
             scopeMock.Verify(scope => scope.Dispose());
         }
+
+        /// <summary>
+        /// When the scope reference is garbage collected the scope is not disposed.
+        /// </summary>
+        [Fact]
+        public void GarbageCollectDoesNotDisposeTheReferencedScope()
+        {
+            var scopeMock = new Mock<IDisposable>();
+            var testee = new NamedScopeReference(scopeMock.Object);
+            testee = null;
+
+            GC.Collect();
+
+            scopeMock.Verify(scope => scope.Dispose(), Times.Never());
+        }
     }
 }
 #endif

--- a/src/Ninject.Extensions.NamedScope/NamedScopeReference.cs
+++ b/src/Ninject.Extensions.NamedScope/NamedScopeReference.cs
@@ -46,7 +46,8 @@ namespace Ninject.Extensions.NamedScope
         /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
         public override void Dispose(bool disposing)
         {
-            this.scope.Dispose();
+            if (disposing)
+                this.scope.Dispose();
             base.Dispose(disposing);
         }
     }


### PR DESCRIPTION
The function would call Dispose into the scope object during a garbage collection, which it shouldn't.

There is probably also an issue with DisposeNotifyingObject.Dispose(bool).

Signed-off-by: Peter Strøiman peter.stroeiman@falck.dk
