### PR TITLE
Mentioned CreateNamedScope and removed some misleading text from Readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,7 @@
-This Ninject Extension enables more powerful higher-level scoping mechanisms to be defined than those offered in the Kernel itself such as
+This Ninject Extension enables more powerful higher-level scoping mechanisms to be defined than those offered in the Kernel itself such as:
 - InParentScope to define a lifetime relative to that of the Request that triggered a resolution of a Binding
-- InCallScope to tie the lifetime to that of the Root Request [and constrain to a single instance within the hierarchy of the] Request being Resolved (See also Ninject.Extensions.ContextPreservation for the ability to be able to extend this to items generated via factories (including Ninject.Extensions.Factory) later in the processing lifecycle)
-- DefinesNameScope / InNamedScope to define a custom pooling rules which one can explicitly Kernel.Release as part of the processing flow 
+- InCallScope to tie the lifetime to that of the Root Request [and constrain to a single instance within the hierarchy of the] Request being Resolved
+- DefinesNamedScope / InNamedScope to enable custom pooling rules
+- CreateNamedScope allows a Named Scope equivalent to one induced by DefinesNamedScope() to be generated programmatically (and Disposed as desired)
 
 More information is found in the wiki: https://github.com/ninject/ninject.extensions.namedscope/wiki


### PR DESCRIPTION
Mentioned CreateNamedScope
Removed inaccurate characterizations 
Removed speculative text to keep text brief

Also propose new description in line with content: This extension enables Bindings to define Scopes. Dependencies can then define that they want to use such Instances as their Scope. Also offers a programmatic equivalent which can be used to deterministically manage a composition tree for request processing scenarios.
